### PR TITLE
fix filename sanitization for directory names

### DIFF
--- a/lib/screens/view_document.dart
+++ b/lib/screens/view_document.dart
@@ -118,7 +118,8 @@ class _ViewDocumentState extends State<ViewDocument>
 
   Future<void> createDirectoryPath() async {
     Directory? appDir = await getExternalStorageDirectory();
-    String dirPath = "${appDir?.path}/OpenScan ${DateTime.now()}";
+    String dirPath =
+        "${appDir?.path}/OpenScan ${DateTime.now().toString().replaceAll(':', '-')}";
     String fileName = dirPath.substring(dirPath.lastIndexOf("/") + 1);
     widget.directoryOS.dirPath = dirPath;
     widget.directoryOS.dirName = fileName;


### PR DESCRIPTION
issue (#113)
I created a pull request that replaces : with - in the generated directory name.
This should prevent filename issues when exporting files to Nextcloud.

the directory name was created using DateTime.now() which includes : characters

this change replaces : with - when creating the directory name

this helps avoid filename issues when exporting files to Nextcloud and other file systems