### PR TITLE
fix(android): pin camera_android_camerax to 0.7.4+6 for AGP 9 compatibility

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
     source: hosted
     version: "0.12.0+2"
   camera_android_camerax:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: camera_android_camerax
       sha256: "47aa7c2963ceb8db4fc3dfbba0f9195da3741f3d11e80f0e29472d46bf4c2e66"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,8 @@ environment:
 dependencies:
   bloc: ^8.1.0
   camera: ^0.12.0
+  # Pin: 0.7.2 applies the legacy kotlin-android Gradle plugin, which AGP 9 rejects.
+  camera_android_camerax: ^0.7.4+6
   camera_platform_interface: ^2.9.0
   cupertino_icons:
   exif:


### PR DESCRIPTION
0.7.2 applies the legacy org.jetbrains.kotlin.android Gradle plugin, which AGP 9 rejects with a hard error. F-Droid CI re-resolves deps via pub get and landed on 0.7.2; pinning forces the AGP-9-compatible line.